### PR TITLE
fix(hash): moved setHash() call to onTransitionEnd

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1476,7 +1476,7 @@ s.onTransitionEnd = function (runCallbacks) {
         if (s.params.onTransitionEnd) s.params.onTransitionEnd(s);
         if (s.params.onSlideChangeEnd && s.activeIndex !== s.previousIndex) s.params.onSlideChangeEnd(s);
     }
-        
+    if (s.params.hashnav && s.hashnav) s.hashnav.setHash();
 };
 s.slideNext = function (runCallbacks, speed, internal) {
     if (s.params.loop) {
@@ -1549,9 +1549,6 @@ s.setWrapperTranslate = function (translate, updateActiveIndex, byController) {
     }
     if (s.params.control && s.controller) {
         s.controller.setTranslate(s.translate, byController);
-    }
-    if (s.params.hashnav && s.hashnav) {
-        s.hashnav.setHash();
     }
     if (s.params.onSetTranslate) s.params.onSetTranslate(s, s.translate);
 };


### PR DESCRIPTION
1.  There's UI lag on hashchange during the animation.       this is a browser issue, and not Swiper.    (tested with your demo 25-hash-navigation.html)
   The proposed fix overrides this, by setting the hash after transition has ended.
2.  logically, there is no need to set the new hash, until I've stopped swiping. For example: while finger-swiping across multiple slides.     
